### PR TITLE
Timekeeping

### DIFF
--- a/examples/Chemotaxis/chemotaxis_xie.jl
+++ b/examples/Chemotaxis/chemotaxis_xie.jl
@@ -40,7 +40,6 @@ model_properties = Dict(
     :C₁ => C₁,
     :t₁ => t₁,
     :t₂ => t₂,
-    :t => 0,
 )
 
 model = initialise_model(;
@@ -48,13 +47,10 @@ model = initialise_model(;
     extent, model_properties
 )
 
-update_model!(model) = (model.t += 1)
-my_model_step!(model) = model_step!(model; update_model!)
-
 _β(a) = motilestate(a.motility) == ForwardState() ? a.gain_forward : a.gain_backward
 state(a::AbstractXie) = max(1 + _β(a)*a.state, 0)
 adata = [state, :state_m, :state_z]
-adf, = run!(model, microbe_step!, my_model_step!, nsteps; adata)
+adf, = run!(model, microbe_step!, model_step!, nsteps; adata)
 S = vectorize_adf_measurement(adf, :state)'
 m = (vectorize_adf_measurement(adf, :state_m)')[:,1] # take only fw
 z = (vectorize_adf_measurement(adf, :state_z)')[:,1] # take only fw

--- a/src/model.jl
+++ b/src/model.jl
@@ -47,6 +47,7 @@ function initialise_model(;
     end # if
 
     properties = Dict(
+        :t => 0,
         :timestep => timestep,
         :compound_diffusivity => 608.0,
         :concentration_field => (pos,model) -> 0.0,

--- a/src/step_model.jl
+++ b/src/step_model.jl
@@ -14,9 +14,9 @@ function model_step!(model;
     if haskey(model.properties, :integrator)
         step!(model.integrator, model.timestep, true)
     end # if
-    # update model properties
-    update_model!(model)
     # increase step count
     model.t += 1
+    # update model properties
+    update_model!(model)
     return nothing
 end # function

--- a/src/step_model.jl
+++ b/src/step_model.jl
@@ -8,11 +8,14 @@ If `model` contains an OrdinaryDiffEq integrator among its
 properties (`model.properties.integrator`), also perform an integration step.
 """
 function model_step!(model;
-    update_model!::Function = (model) -> nothing)
+    update_model!::Function = (model) -> nothing
+)
     # if a diffeq integrator is provided, integrate over a timestep
     if haskey(model.properties, :integrator)
         step!(model.integrator, model.timestep, true)
     end # if
     # update model properties
     update_model!(model)
+    # increase step count
+    model.t += 1
 end # function

--- a/src/step_model.jl
+++ b/src/step_model.jl
@@ -18,4 +18,5 @@ function model_step!(model;
     update_model!(model)
     # increase step count
     model.t += 1
+    return nothing
 end # function

--- a/test/model_creation.jl
+++ b/test/model_creation.jl
@@ -26,7 +26,7 @@ using Test, Bactos, Random
     # test default properties
     @test model.properties isa Dict{Symbol,Any}
     @test Set(keys(model.properties)) == Set(
-        (:timestep, :compound_diffusivity, :concentration_field,
+        (:t, :timestep, :compound_diffusivity, :concentration_field,
         :concentration_gradient, :concentration_time_derivative, :integrator)
     )
     @test model.timestep == timestep


### PR DESCRIPTION
Introduces a new model property `t` which keeps track of current simulation time (number of steps).
Can be used to control other model properties in a time-dependent way.

Closes #14 