### PR TITLE
New `MotileState` and `TwoState` types

### DIFF
--- a/examples/Chemotaxis/chemotaxis_xie.jl
+++ b/examples/Chemotaxis/chemotaxis_xie.jl
@@ -15,8 +15,8 @@ concentration_field(t,C₀,C₁,t₁,t₂) = C₀+C₁*θ(t,t₁)*(1-θ(t,t₂))
 concentration_gradient(pos, model) = zero.(pos) # not used by Xie
 concentration_time_derivative(pos, model) = 0.0 # not used by Xie
 
-motility_fw = RunReverseFlick(motile_state = TwoStates(ForwardState()))
-motility_bw = RunReverseFlick(motile_state = TwoStates(BackwardState()))
+motility_fw = RunReverseFlick(motile_state = MotileState(Forward))
+motility_bw = RunReverseFlick(motile_state = MotileState(Backward))
 microbes = [
     XieNoisy{3}(id=1, turn_rate_forward=0, motility=motility_fw),
     XieNoisy{3}(id=2, turn_rate_backward=0, motility=motility_bw)
@@ -47,8 +47,8 @@ model = initialise_model(;
     extent, model_properties
 )
 
-_β(a) = motilestate(a.motility) == ForwardState() ? a.gain_forward : a.gain_backward
-state(a::AbstractXie) = max(1 + _β(a)*a.state, 0)
+β(a) = a.motility.state == Forward ? a.gain_forward : a.gain_backward
+state(a::AbstractXie) = max(1 + β(a)*a.state, 0)
 adata = [state, :state_m, :state_z]
 adf, = run!(model, microbe_step!, model_step!, nsteps; adata)
 S = vectorize_adf_measurement(adf, :state)'

--- a/src/motility.jl
+++ b/src/motility.jl
@@ -42,10 +42,19 @@ mutable struct MotileState
     state
 end
 MotileState() = MotileState(TwoState())
+"""
+    TwoState <: Enum{Bool}
+Represents the state of a two-step motile pattern, can take values
+`Forward` or `Backward`.
+"""
 @enum TwoState::Bool Forward Backward
 Base.show(io::IO, ::MIME"text/plain", x::TwoState) = 
     x == Forward ? print(io, "Forward") : print(io, "Backward")
 # choose at random between Forward and Backward if not specified
+"""
+    TwoState([rng::AbstractRng])
+Randomly generate the state of a two-step motile pattern.
+"""
 TwoState() = TwoState(Random.default_rng())
 TwoState(rng::AbstractRNG) = TwoState(rand(rng, (true, false)))
 # overload getproperty and setproperty! for more convenient access to state
@@ -65,6 +74,11 @@ function Base.setproperty!(value::AbstractMotilityTwoStep, name::Symbol, x)
 end
 # define rules for switching motile state
 switch!(::AbstractMotilityOneStep) = nothing
+""" 
+    switch!(m::AbstractMotilityTwoStep)
+Switch the state of a two-step motility pattern (`m.state`)
+from `Forward` to `Backward` and viceversa.
+"""
 switch!(m::AbstractMotilityTwoStep) = (m.state = ~m.state; nothing)
 Base.:~(x::TwoState) = TwoState(~Bool(x))
 

--- a/src/motility.jl
+++ b/src/motility.jl
@@ -65,8 +65,7 @@ function Base.setproperty!(value::AbstractMotilityTwoStep, name::Symbol, x)
 end
 # define rules for switching motile state
 switch!(::AbstractMotilityOneStep) = nothing
-switch!(m::AbstractMotilityTwoStep) = switch!(m.state)
-switch!(s::TwoState) = (s = ~s; nothing)
+switch!(m::AbstractMotilityTwoStep) = (m.state = ~m.state; nothing)
 Base.:~(x::TwoState) = TwoState(~Bool(x))
 
 Base.@kwdef struct RunTumble <: AbstractMotilityOneStep

--- a/src/motility.jl
+++ b/src/motility.jl
@@ -43,6 +43,8 @@ mutable struct MotileState
 end
 MotileState() = MotileState(TwoState())
 @enum TwoState::Bool Forward Backward
+Base.show(io::IO, ::MIME"text/plain", x::TwoState) = 
+    x == Forward ? print(io, "Forward") : print(io, "Backward")
 # choose at random between Forward and Backward if not specified
 TwoState() = TwoState(Random.default_rng())
 TwoState(rng::AbstractRNG) = TwoState(rand(rng, (true, false)))

--- a/src/rotations.jl
+++ b/src/rotations.jl
@@ -42,13 +42,13 @@ function turn!(microbe::AbstractMicrobe, motility::AbstractMotilityTwoStep)
     # store current speed
     U₀ = norm(microbe.vel)
     # perform reorientation depending on current motile state
-    if motilestate(motility) == ForwardState()
+    if motility.state == Forward
         # reorient according to forward-state angles
         θ = rand(motility.polar_forward)
         ϕ = rand(motility.azimuthal_forward)
         # extract new speed from backward-state distribution
         U₁ = rand(motility.speed_backward)
-    elseif motilestate(motility) == BackwardState()
+    elseif motility.state == Backward
         # reorient according to backward-state angles
         θ = rand(motility.polar_backward)
         ϕ = rand(motility.azimuthal_backward)
@@ -57,8 +57,8 @@ function turn!(microbe::AbstractMicrobe, motility::AbstractMotilityTwoStep)
     end # if
     # reorient
     microbe.vel = rotate(microbe.vel, θ, ϕ) |> Tuple
-    # update motile state
-    switch!(motility.motile_state)
+    # switch motile state
+    switch!(motility)
     # update speed
     microbe.vel = microbe.vel .* (U₁ / U₀)
     return nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,8 +27,7 @@ If `motilestate(m) == ForwardState()` extract from `speed_forward`, otherwise
 from `speed_backward`.
 """
 function rand_speed(m::AbstractMotilityTwoStep)
-    s = motilestate(m)
-    if s == ForwardState()
+    if m.state == Forward
         return rand(m.speed_forward)
     else
         return rand(m.speed_backward)

--- a/src/xie.jl
+++ b/src/xie.jl
@@ -97,10 +97,10 @@ function xie_turnrate_onestep(microbe, model)
 end
 function xie_turnrate_twostep(microbe, model)
     S = microbe.state
-    if motility.state == Forward
+    if microbe.motility.state == Forward
         ν₀ = microbe.turn_rate_forward
         β = microbe.gain_forward
-    elseif motility.state == Backward
+    else
         ν₀ = microbe.turn_rate_backward
         β = microbe.gain_backward
     end

--- a/src/xie.jl
+++ b/src/xie.jl
@@ -83,6 +83,19 @@ function xie_affect!(microbe::XieNoisy, model; ε=1e-16)
 end
 
 function xie_turnrate(microbe, model)
+    if microbe.motility isa AbstractMotilityTwoStep
+        return xie_turnrate_twostep(microbe, model)
+    else
+        return xie_turnrate_onestep(microbe, model)
+    end
+end
+function xie_turnrate_onestep(microbe, model)
+    S = microbe.state
+    ν₀ = microbe.turn_rate_forward
+    β = microbe.gain_forward
+    return ν₀*(1 + β*S)
+end
+function xie_turnrate_twostep(microbe, model)
     S = microbe.state
     if motility.state == Forward
         ν₀ = microbe.turn_rate_forward

--- a/src/xie.jl
+++ b/src/xie.jl
@@ -84,11 +84,10 @@ end
 
 function xie_turnrate(microbe, model)
     S = microbe.state
-    motile_state = motilestate(microbe.motility)
-    if motile_state == ForwardState()
+    if motility.state == Forward
         ν₀ = microbe.turn_rate_forward
         β = microbe.gain_forward
-    elseif motile_state == BackwardState()
+    elseif motility.state == Backward
         ν₀ = microbe.turn_rate_backward
         β = microbe.gain_backward
     end

--- a/test/motility.jl
+++ b/test/motility.jl
@@ -2,10 +2,24 @@ using Test, Bactos, Random
 using Distributions: Uniform
 
 @testset "Motility" begin
+    @testset "Motile state" begin
+        @test instances(TwoState) == (Forward, Backward)
+        # call without argument chooses an instance at random
+        @test TwoState() ∈ instances(TwoState)
+        # bitwise not switches between Forward and Backward
+        @test ~Forward == Backward
+        @test ~Backward == Forward
+        # call to MotileState without argument chooses random state
+        motstate = MotileState()
+        @test motstate.state ∈ instances(TwoState)
+        # or the instance can be specified
+        motstate = MotileState(Forward)
+        @test motstate.state == Forward
+    end
+
     @test AbstractMotilityOneStep <: AbstractMotility
     @test AbstractMotilityTwoStep <: AbstractMotility
     @test !(AbstractMotilityOneStep <: AbstractMotilityTwoStep)
-    @test TwoStates <: AbstractMotileState
 
     @test RunTumble <: AbstractMotilityOneStep
     m = RunTumble()
@@ -21,8 +35,19 @@ using Distributions: Uniform
     @test m.speed_backward === m.speed_forward
     @test m.polar_backward === m.polar_forward
     @test m.azimuthal_backward === m.azimuthal_forward
-    @test m.motile_state isa TwoStates
-    @test motilestate(m) ∈ (ForwardState(), BackwardState())
+    @test m.motile_state isa MotileState
+    # no :state field, but due to getproperty! overload
+    # it directly accesses motile_state.state
+    @test !hasfield(RunReverse, :state)
+    @test m.state === m.motile_state.state
+    @test m.state isa TwoState
+    # switching motility equals to switching state
+    s = m.state
+    switch!(m)
+    @test m.state == ~s
+    # state can be set manually due to setproperty! overload
+    m.state = Forward
+    @test m.state == Forward
 
     @test RunReverseFlick <: AbstractMotilityTwoStep
     m = RunReverseFlick()
@@ -32,6 +57,10 @@ using Distributions: Uniform
     @test m.speed_backward === m.speed_forward
     @test m.polar_backward == [-π/2, π/2]
     @test m.azimuthal_backward === m.azimuthal_forward
-    @test m.motile_state isa TwoStates
-    @test motilestate(m) ∈ (ForwardState(), BackwardState())
+    @test m.motile_state isa MotileState
+    # no :state field, but due to getproperty! overload
+    # it directly accesses motile_state.state
+    @test !hasfield(RunReverse, :state)
+    @test m.state === m.motile_state.state
+    @test m.state isa TwoState
 end

--- a/test/reorientations.jl
+++ b/test/reorientations.jl
@@ -16,16 +16,16 @@ using Distributions: Uniform, Normal
         turn!(m, m.motility)
         @test vel == m.vel
 
-        motile_state = TwoStates(ForwardState())
+        motile_state = MotileState(Forward)
         motility = RunReverseFlick(speed_forward=[1.0]; motile_state)
         vel = (1.0,)
         m = Microbe{1}(id=1; vel, motility)
         turn!(m, m.motility)
         @test vel == .-m.vel
-        @test motilestate(motility) == BackwardState()
+        @test motility.state == Backward
         turn!(m, m.motility)
         @test vel == m.vel
-        @test motilestate(motility) == ForwardState()
+        @test motility.state == Forward
     end
 
     @testset "Two-dimensional reorientations" begin
@@ -52,7 +52,7 @@ using Distributions: Uniform, Normal
         vel = rand_vel(2) .* U
         motility = RunReverseFlick(
             speed_forward = [U],
-            motile_state = TwoStates(ForwardState()),
+            motile_state = MotileState(Forward),
             polar_backward = [π/2] # exclude -π/2
         )
         m = Microbe{2}(id=1; vel, motility)


### PR DESCRIPTION
Introduces new `MotileState` type as a wrapper around a mutable state, and a new `TwoState` type which is enumerated and has instances `Forward` and `Backward`.

Closes #66 