### PR TITLE
Don't initialize ODE `integrator` automatically

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -1,10 +1,6 @@
 export
     initialise_model, initialise_ode, initialise_pathfinder
 
-
-global const dummy_ODEProblem::ODEProblem = ODEProblem((du,u,p,t) -> nothing, [0.0], 0.0)
-global const dummy_integrator::DEIntegrator = init(dummy_ODEProblem, Tsit5())
-
 """
     initialise_model(;
         microbes,
@@ -12,7 +8,6 @@ global const dummy_integrator::DEIntegrator = init(dummy_ODEProblem, Tsit5())
         extent, spacing = extent/20, periodic = true,
         random_positions = true,
         model_properties = Dict(),
-        diffeq = false, ode_integrator = dummy_integrator
     )
 Initialise an `AgentBasedModel` from population `microbes`.
 Requires the integration `timestep` and the `extent` of the simulation box.
@@ -23,10 +18,6 @@ if `random_positions = false` the original positions in `microbes` are kept.
 
 Any extra property can be assigned to the model via the `model_properties`
 dictionary.
-
-Set `diffeq = true` and provide an `ode_integrator` (e.g. through the
-`initialise_ode` function) to integrate a differential equation in parallel
-to microbe stepping.
 """
 function initialise_model(;
     microbes,
@@ -34,7 +25,6 @@ function initialise_model(;
     extent, spacing = minimum(extent)/20, periodic = true,
     random_positions = true,
     model_properties = Dict(),
-    ode_integrator = dummy_integrator,
 )
     space_dim = length(microbes[1].pos)
     if typeof(extent) <: Real
@@ -53,7 +43,6 @@ function initialise_model(;
         :concentration_field => (pos,model) -> 0.0,
         :concentration_gradient => (pos,model) -> zero.(pos),
         :concentration_time_derivative => (pos,model) -> 0.0,
-        :integrator => ode_integrator,
         model_properties...
     )
 

--- a/src/step_model.jl
+++ b/src/step_model.jl
@@ -5,7 +5,7 @@ export model_step!
 Update model properties through the `update_model!` function
 (defaults to nothing).
 If `model` contains an OrdinaryDiffEq integrator among its
-properties (`model.properties.integrator`), also perform an integration step.
+properties (`model.integrator`), also perform an integration step.
 """
 function model_step!(model;
     update_model!::Function = (model) -> nothing

--- a/test/model_creation.jl
+++ b/test/model_creation.jl
@@ -27,7 +27,7 @@ using Test, Bactos, Random
     @test model.properties isa Dict{Symbol,Any}
     @test Set(keys(model.properties)) == Set(
         (:t, :timestep, :compound_diffusivity, :concentration_field,
-        :concentration_gradient, :concentration_time_derivative, :integrator)
+        :concentration_gradient, :concentration_time_derivative)
     )
     @test model.timestep == timestep
     # the model should contain the agent `m`, not a copy
@@ -103,7 +103,7 @@ using Test, Bactos, Random
 
         model = initialise_model(;
             microbes, timestep, extent,
-            ode_integrator = integrator
+            model_properties = Dict(:integrator => integrator)
         )
         @test model.integrator === integrator
         # advance ode for n steps of size timestep


### PR DESCRIPTION
* Removes auto-initialisation of ODE `integrator` in `initialise_model`
* Removes typed global consts `dummy_ODEProblem` and `dummy_integrator` used for such initialisation (this also allows compatibility with julia pre-1.8)

Closes #73.

